### PR TITLE
[C-EML-022] Add canonical addresses to send stats logs

### DIFF
--- a/emailbot/messaging_utils.py
+++ b/emailbot/messaging_utils.py
@@ -1,0 +1,31 @@
+"""Utility helpers for working with email addresses."""
+
+from __future__ import annotations
+
+
+def canonical_for_history(email: str) -> str:
+    """Return a canonical representation of an email address.
+
+    The helper is intentionally conservative: it normalizes whitespace and
+    casing for every domain but applies Gmail-specific canonicalization rules
+    so that addresses like ``username+tag@gmail.com`` and ``username@gmail.com``
+    are treated as the same entity when analysing historical logs.
+    """
+
+    if not email:
+        return ""
+
+    normalized = email.strip().lower()
+    if "@" not in normalized:
+        return normalized
+
+    local_part, _, domain = normalized.partition("@")
+    if not local_part or not domain:
+        return normalized
+
+    if domain in {"gmail.com", "googlemail.com"}:
+        local_part = local_part.split("+", 1)[0]
+        local_part = local_part.replace(".", "")
+        domain = "gmail.com"
+
+    return f"{local_part}@{domain}"

--- a/tests/test_send_stats_canon.py
+++ b/tests/test_send_stats_canon.py
@@ -1,0 +1,16 @@
+import json
+
+from emailbot.messaging_utils import canonical_for_history
+from utils import send_stats
+
+
+def test_log_success_includes_canon(tmp_path, monkeypatch):
+    log_path = tmp_path / "stats.jsonl"
+    monkeypatch.setattr(send_stats, "LOG_FILE", str(log_path))
+
+    send_stats.log_success("user.name+tag@gmail.com", group="test")
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    rec = json.loads(lines[0])
+    assert rec["email"] == "user.name+tag@gmail.com"
+    assert rec["to_canon"] == canonical_for_history("user.name+tag@gmail.com")

--- a/utils/send_stats.py
+++ b/utils/send_stats.py
@@ -1,20 +1,94 @@
-"""Legacy statistics helpers.
+"""Helpers for logging historical email sending statistics."""
 
-These functions previously worked with JSONL logs but are kept
-for compatibility. They are not used by the bot anymore."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from emailbot.messaging_utils import canonical_for_history
+
+LOG_FILE = Path(__file__).resolve().parents[1] / "var" / "send_stats.jsonl"
 
 
-def summarize_today(*_args, **_kwargs):  # pragma: no cover - legacy stub
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _append_jsonl(record: Mapping[str, Any]) -> None:
+    path = Path(LOG_FILE)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        json.dump(record, fh, ensure_ascii=False)
+        fh.write("\n")
+
+
+def log_success(email: str, group: str, extra: dict[str, Any] | None = None) -> None:
+    rec: dict[str, Any] = {
+        "ts": _now_utc().isoformat().replace("+00:00", "Z"),
+        "email": (email or "").strip(),
+        "to_canon": canonical_for_history(email or ""),
+        "group": (group or "").strip().lower(),
+        "status": "success",
+    }
+    if extra:
+        rec.update(extra)
+    _append_jsonl(rec)
+
+
+def log_error(
+    email: str,
+    group: str,
+    error: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    rec: dict[str, Any] = {
+        "ts": _now_utc().isoformat().replace("+00:00", "Z"),
+        "email": (email or "").strip(),
+        "to_canon": canonical_for_history(email or ""),
+        "group": (group or "").strip().lower(),
+        "status": "error",
+        "error": (error or "").strip(),
+    }
+    if extra:
+        rec.update(extra)
+    _append_jsonl(rec)
+
+
+def log_bounce(
+    email: str,
+    group: str,
+    error: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    rec: dict[str, Any] = {
+        "ts": _now_utc().isoformat().replace("+00:00", "Z"),
+        "email": (email or "").strip(),
+        "to_canon": canonical_for_history(email or ""),
+        "group": (group or "").strip().lower(),
+        "status": "bounce",
+        "error": (error or "").strip(),
+    }
+    if extra:
+        rec.update(extra)
+    _append_jsonl(rec)
+
+
+# Legacy compatibility helpers -------------------------------------------------
+
+
+def summarize_today(*_args: Any, **_kwargs: Any) -> int:  # pragma: no cover
     return 0
 
 
-def summarize_week(*_args, **_kwargs):  # pragma: no cover - legacy stub
+def summarize_week(*_args: Any, **_kwargs: Any) -> int:  # pragma: no cover
     return 0
 
 
-def summarize_month(*_args, **_kwargs):  # pragma: no cover - legacy stub
+def summarize_month(*_args: Any, **_kwargs: Any) -> int:  # pragma: no cover
     return 0
 
 
-def summarize_year(*_args, **_kwargs):  # pragma: no cover - legacy stub
+def summarize_year(*_args: Any, **_kwargs: Any) -> int:  # pragma: no cover
     return 0


### PR DESCRIPTION
## Summary
- add canonical email canonicalization helper for history logging
- extend send stats logging helpers to store canonical address alongside raw email
- add regression test covering the JSONL payload format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a03c2ee88326928dcfe7a15bb040