### PR TITLE
Add email normalization pipeline with IDNA validation

### DIFF
--- a/pipelines/extract_emails.py
+++ b/pipelines/extract_emails.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from emailbot.extraction import detach_list_markers
+from emailbot.messaging_utils import canonical_for_history
+from utils.email_clean import (
+    normalize_domain_idna,
+    sanitize_email,
+    validate_email_syntax,
+)
+
+_LOCAL_PART = r"[^\s<>()\[\],;]+"
+_DOMAIN_LABEL = r"[^\s<>()\[\],;@.]+"
+_CANDIDATE_RE = re.compile(
+    rf"({_LOCAL_PART}@(?:{_DOMAIN_LABEL}\.)+{_DOMAIN_LABEL})",
+    re.UNICODE,
+)
+
+
+def _iter_candidates(text: str) -> Iterable[str]:
+    cleaned = detach_list_markers(text or "")
+    seen: set[str] = set()
+    for match in _CANDIDATE_RE.finditer(cleaned):
+        cand = match.group(1)
+        if cand not in seen:
+            seen.add(cand)
+            yield cand
+
+
+def run_pipeline_on_text(text: str) -> tuple[list[str], list[tuple[str, str]]]:
+    final: list[str] = []
+    dropped: list[tuple[str, str]] = []
+    seen_canon: set[str] = set()
+
+    for cand in _iter_candidates(text):
+        sanitized, sanitize_reason = sanitize_email(cand)
+        if not sanitized:
+            dropped.append((cand, sanitize_reason or "sanitize-failed"))
+            continue
+
+        local, sep, domain = sanitized.partition("@")
+        if not sep or not domain:
+            dropped.append((sanitized, "missing-domain"))
+            continue
+
+        ok, domain_norm, reason = normalize_domain_idna(domain)
+        if not ok:
+            dropped.append((sanitized, reason or "invalid-idna"))
+            continue
+
+        addr = f"{local}@{domain_norm}"
+
+        ok, reason = validate_email_syntax(addr)
+        if not ok:
+            dropped.append((sanitized, reason or "invalid-email"))
+            continue
+
+        canon = canonical_for_history(addr)
+        if canon in seen_canon:
+            continue
+        seen_canon.add(canon)
+        final.append(addr)
+
+    return final, dropped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+email-validator==2.1.1.post1
+idna==3.7

--- a/tests/test_idna_validation.py
+++ b/tests/test_idna_validation.py
@@ -1,0 +1,18 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from pipelines.extract_emails import run_pipeline_on_text
+
+
+def test_idna_russian_domain_converted():
+    raw = "Пишите на info@почта.рф"
+    final, dropped = run_pipeline_on_text(raw)
+    assert any(e.endswith("@xn--80a1acny.xn--p1ai") for e in final)
+
+
+def test_invalid_label_rejected():
+    raw = "mail me: ivan@exa_mple.com"
+    final, dropped = run_pipeline_on_text(raw)
+    assert "ivan@exa_mple.com" in [d[0] for d in dropped]

--- a/utils/email_clean.py
+++ b/utils/email_clean.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from email_validator import EmailNotValidError, validate_email
+import idna
+import re
+
+_TLD_RE = r"(?:[A-Za-z]{2,24})"
+_TAIL_CUT = re.compile(rf"^(.+?\.(?:{_TLD_RE}))([>\)\]:;,\s].*)$")
+
+
+def _trim_after_tld(addr: str) -> str:
+    """Обрезает хвосты после корректного TLD: '>: ] ) , ;' и пробел."""
+    m = _TAIL_CUT.match(addr)
+    return m.group(1) if m else addr
+
+
+_STRIP_CHARS = "\'\"<>[](){}"
+_TRAIL_PUNCT = "."
+
+
+def sanitize_email(addr: str) -> tuple[str, str | None]:
+    """Простая очистка e-mail от обрамляющих символов и хвостов."""
+    candidate = (addr or "").strip()
+    if not candidate:
+        return "", "empty"
+    candidate = candidate.strip(_STRIP_CHARS)
+    candidate = _trim_after_tld(candidate)
+    candidate = candidate.rstrip(_TRAIL_PUNCT)
+    return candidate, (None if candidate else "empty")
+
+
+def normalize_domain_idna(domain: str) -> tuple[bool, str, str | None]:
+    """
+    Приводит домен к нижнему регистру и, при необходимости, к Punycode.
+    Возвращает (ok, normalized, reason|None).
+    """
+    try:
+        d = (domain or "").strip().lower()
+        if not d or len(d) > 253:
+            return False, "", "invalid-domain-length"
+        labels = d.split(".")
+        out_labels: list[str] = []
+        for label in labels:
+            if not label or len(label) > 63:
+                return False, "", "invalid-label-length"
+            if any(ord(c) > 127 for c in label):
+                label = idna.encode(label).decode("ascii")
+            if not re.fullmatch(r"[a-z0-9-]{1,63}", label) or label.startswith("-") or label.endswith("-"):
+                return False, "", "invalid-label"
+            out_labels.append(label)
+        d_norm = ".".join(out_labels)
+        if len(out_labels[-1]) < 2 or len(out_labels[-1]) > 24:
+            return False, "", "invalid-tld"
+        return True, d_norm, None
+    except Exception:
+        return False, "", "invalid-idna"
+
+
+def validate_email_syntax(addr: str) -> tuple[bool, str | None]:
+    """
+    Проверяет e-mail на синтаксис (без DNS/SMPP).
+    Возвращает (ok, reason|None).
+    """
+    try:
+        validate_email(addr, allow_smtputf8=False, check_deliverability=False)
+        return True, None
+    except EmailNotValidError as e:
+        return False, f"invalid-email:{str(e)[:80]}"


### PR DESCRIPTION
## Summary
- add utilities for sanitizing and validating email domains with email-validator and IDNA support
- implement an extraction pipeline that normalizes domains, validates syntax, and de-duplicates addresses
- cover IDNA conversion and invalid label rejection with new tests and dependencies

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'email_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68c9a3039fc08326b2f69ed8c9265319